### PR TITLE
Fix infinite fuel exploit and overclock module 2 tech tier

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.1.20
+Date: 06.16.2026
+  Bugfixes:
+    - liquid fuel canister/bottle conversion recipes can no longer receive any productivity, fixing an exploit that allowed infinite fuel by looping fuel through productivity research
+    - Overclock module 2 research is now at the same tier as other level 2 modules (chemical science) instead of being gated behind space science
+---------------------------------------------------------------------------------------------------
 Version: 0.1.19
 Date: 06.08.2026
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-and-stars",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "title": "Metal and Stars",
   "author": "5forSilver",
   "description": "It's a big universe out there, and there are other ways to leave the solar system. Several new destinations with new machines, technologies, and unique processes",

--- a/prototypes/planet/technology-advanced.lua
+++ b/prototypes/planet/technology-advanced.lua
@@ -36,16 +36,15 @@ data:extend({
             recipe = "overclock-module-2"
           }
         },
-        prerequisites = {"overclock-module", "space-science-pack"},
+        prerequisites = {"overclock-module", "processing-unit"},
         unit =
         {
-          count = 200,
+          count = 100,
           ingredients =
           {
             {"automation-science-pack", 1},
             {"logistic-science-pack", 1},
-            {"chemical-science-pack", 1},
-            {"space-science-pack", 1}
+            {"chemical-science-pack", 1}
           },
           time = 30
         },

--- a/prototypes/recipes-liquid-fuel.lua
+++ b/prototypes/recipes-liquid-fuel.lua
@@ -83,7 +83,7 @@ data:extend({
       secondary = {r = 1.0, g = 0.7, b = 0.0, a = 1.000},
     },
     allow_productivity = false,
-      maximum_productivity = 1
+      maximum_productivity = 0
   },
   {
     type = "recipe",
@@ -104,7 +104,7 @@ data:extend({
       secondary = {r = 1.0, g = 0.7, b = 0.0, a = 1.000},
     },
     allow_productivity = false,
-      maximum_productivity = 1
+      maximum_productivity = 0
   },
   {
     type = "recipe",
@@ -125,7 +125,7 @@ data:extend({
       secondary = {r = 1.0, g = 0.7, b = 0.0, a = 1.000},
     },
     allow_productivity = false,
-      maximum_productivity = 1
+      maximum_productivity = 0
   },
     --//// canister Recipes
     {
@@ -147,7 +147,7 @@ data:extend({
         secondary = {r = 1.0, g = 0.7, b = 0.0, a = 1.000},
       },
       allow_productivity = false,
-      maximum_productivity = 1
+      maximum_productivity = 0
     },
     {
       type = "recipe",
@@ -168,7 +168,7 @@ data:extend({
         secondary = {r = 1.0, g = 0.7, b = 0.0, a = 1.000},
       },
       allow_productivity = false,
-      maximum_productivity = 1
+      maximum_productivity = 0
     },
     {
       type = "recipe",
@@ -189,6 +189,6 @@ data:extend({
         secondary = {r = 1.0, g = 0.7, b = 0.0, a = 1.000},
       },
       allow_productivity = false,
-      maximum_productivity = 1
+      maximum_productivity = 0
     },
 })


### PR DESCRIPTION
Re-applies two previously-designed fixes that couldn't be pushed in an earlier session.

## Fixes #20 — Canister liquid fuel infinite-productivity exploit
`prototypes/recipes-liquid-fuel.lua`: changed `maximum_productivity = 1` → `maximum_productivity = 0` on all six fuel conversion recipes (`empty-liquid-{rocket,nuclear,dark-matter}-fuel` and `canister-liquid-{rocket,nuclear,dark-matter}-fuel`).

These are lossless 1:10 / 10:1 conversions. `allow_productivity = false` only blocks productivity *modules*; the global productivity research bonuses still applied, and `maximum_productivity = 1` (100%) still permitted productivity to mint free matter. Looping fuel through the canister↔liquid conversion with any productivity > 0 yielded infinite fuel. Setting the cap to `0` fully disables productivity on these recipes and closes the loop. (`allow_productivity = false` left as-is.)

## Fixes #16 — Overclock module 2 tech tier
`prototypes/planet/technology-advanced.lua`, technology `overclock-module-2`:
- prerequisites: `{"overclock-module", "space-science-pack"}` → `{"overclock-module", "processing-unit"}`
- removed the `{"space-science-pack", 1}` research ingredient (keeps automation, logistic, chemical science packs)
- `count`: 200 → 100

Other level-2 modules sit at the chemical/blue-science tier, and the recipe only uses blue-tier ingredients (advanced-circuit, processing-unit). Space science gated it a full tier too deep.

## Versioning
- `info.json`: `0.1.19` → `0.1.20`
- `changelog.txt`: new `0.1.20` entry (06.16.2026) documenting both bugfixes.