### PR TITLE
Force always-day and hide cloud shadows on Neumann V and Circa

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2,5 +2,5 @@ _G.metal = require "scripts.constants"
 
 require("__metal-and-stars__.lib.control-stage")
 require("__metal-and-stars__.prototypes.dependency-updates.compatibility-scripts")
--- require("__metal-and-stars__.scripts.shipyard-surface")
+require("__metal-and-stars__.scripts.shipyard-surface")
 -- require("__metal-and-stars__.scripts.volantus-platforms")

--- a/migrations/always-day-surfaces.lua
+++ b/migrations/always-day-surfaces.lua
@@ -1,0 +1,10 @@
+-- Back-migration: apply perpetual daylight and hide cloud shadows on surfaces
+-- that already existed before scripts/shipyard-surface.lua handled them on
+-- creation. New surfaces are handled by on_surface_created; this covers saves
+-- where Neumann V ("shipyard") or Circa ("ringworld") were already generated.
+for _, surface in pairs(game.surfaces) do
+	if surface.valid and (surface.name == "shipyard" or surface.name == "ringworld") then
+		surface.always_day = true
+		surface.show_clouds = false
+	end
+end

--- a/scripts/shipyard-surface.lua
+++ b/scripts/shipyard-surface.lua
@@ -1,8 +1,24 @@
-script.on_event(defines.events.on_surface_created, function(event)
-	local surface = game.get_surface(event.surface_index)
-	if not surface or not surface.valid then return end
-	if surface.name ~= "shipyard" then return end
+-- Forces perpetual daylight and hides cloud shadows on the mod's always-day
+-- surfaces: Neumann V ("shipyard") and Circa ("ringworld").
+--
+-- The planet prototypes set ["day-night-cycle"] = 0, but Factorio does not
+-- honour a zero-length cycle (the minimum effective value is 1), so the surfaces
+-- still ran a normal day/night cycle. We lock them to permanent day at runtime
+-- instead. Cloud shadows are also hidden as these surfaces have no atmosphere.
 
-	surface.freeze_daytime = true
+local ALWAYS_DAY_SURFACES = {
+	shipyard = true,  -- Neumann V
+	ringworld = true, -- Circa
+}
+
+local function setup_surface(surface)
+	if not surface or not surface.valid then return end
+	if not ALWAYS_DAY_SURFACES[surface.name] then return end
+
+	surface.always_day = true
 	surface.show_clouds = false
+end
+
+script.on_event(defines.events.on_surface_created, function(event)
+	setup_surface(game.get_surface(event.surface_index))
 end)


### PR DESCRIPTION
Fixes the day/night cycle and cloud-shadow issues on the mod's always-day surfaces.

**Problem**
- Circa (`ringworld`) and Neumann V (`shipyard`) set `["day-night-cycle"] = 0` in their planet prototypes, but Factorio does not honour a zero-length cycle (minimum effective value is 1), so a normal ~7-minute cycle still ran — making solar power unreliable despite the 'always day' description.
- Cloud shadows rendered on Neumann V despite it having no atmosphere.
- `scripts/shipyard-surface.lua` already contained a fix but its `require` in `control.lua` was commented out, and it only covered `shipyard`.

**Change**
- Re-enable the `scripts/shipyard-surface` require in `control.lua`.
- Generalize the script to set `surface.always_day = true` and `surface.show_clouds = false` on both `shipyard` and `ringworld` via `on_surface_created`.
- Add `migrations/always-day-surfaces.lua` so existing saves get the same treatment (back-migration).

Closes #47
Closes #45