### PR TITLE
Liquid fuel heating tower: pipe input from all 4 directions

### DIFF
--- a/prototypes/entity/liquid-fuel-heating-tower.lua
+++ b/prototypes/entity/liquid-fuel-heating-tower.lua
@@ -46,7 +46,12 @@ data:extend({
         pipe_covers = pipecoverspictures(),
         volume = 200,
         secondary_draw_orders = { north = -1 },
-        pipe_connections = {{ flow_direction="input", direction = defines.direction.south, position = {0, 1} }}
+        pipe_connections = {
+          { flow_direction="input", direction = defines.direction.north, position = {0, -1} },
+          { flow_direction="input", direction = defines.direction.east,  position = {1, 0} },
+          { flow_direction="input", direction = defines.direction.south, position = {0, 1} },
+          { flow_direction="input", direction = defines.direction.west,  position = {-1, 0} }
+        }
       },
 
     },


### PR DESCRIPTION
## Problem
The `liquid-fuel-heating-tower` exposed only a single fluid input pipe connection (south, position `{0, 1}`). Players expect to be able to pipe fuel in from any direction, matching the behavior of other fluid-consuming buildings.

## Change
In `prototypes/entity/liquid-fuel-heating-tower.lua`, the `fluid_box.pipe_connections` now defines input connections on all four sides:

- north, position `{0, -1}`
- east, position `{1, 0}`
- south, position `{0, 1}` (existing)
- west, position `{-1, 0}`

All connections use `flow_direction="input"`.

## Balance / uncertainty notes
- This is a QoL/connectivity change only; it does not alter consumption rate, heat output, or any other balance value.
- The entity is a 3x3 (collision box `{-1.25,-1.25}..{1.25,1.25}`), so edge positions at offset ±1 land on the building's border on each side, consistent with how the heat connections are already laid out.
- To verify in-game: place the heating tower and connect a fuel pipe from each of the four sides; each should accept fluid input.

Closes #28