### PR TITLE
Liquid fuel heating towers should consume more liquid per second

### DIFF
--- a/prototypes/entity/liquid-fuel-heating-tower.lua
+++ b/prototypes/entity/liquid-fuel-heating-tower.lua
@@ -32,7 +32,14 @@ data:extend({
       burns_fluid = true,
       emissions_per_minute = {pollution = 50},
       effectivity = 3,
-      fluid_usage_per_tick = .1,
+      -- fluid_usage_per_tick caps the fluid throughput (units/tick) when burns_fluid = true.
+      -- Burned power = fluid_usage_per_tick * 60 * fuel_value * effectivity, clamped to `consumption`.
+      -- The previous value of 0.1 capped throughput at 6 units/s, so even the primary refined
+      -- fuel (liquid-rocket-fuel, 11MJ) only reached 6 * 11MJ * 3 = 198MW, far below the 500MW rating.
+      -- 0.25 -> 15 units/s; with liquid-rocket-fuel that is 15 * 11MJ * 3 = 495MW (~rated capacity),
+      -- so the tower can hit its rated output and higher-energy fuels stay relevant via the 500MW clamp.
+      -- (Crude oil at 1MJ still yields only 45MW, keeping refined fuels worthwhile.)
+      fluid_usage_per_tick = .25,
       light_flicker =
       {
         color = {0,0,0},


### PR DESCRIPTION
## Problem
The Nix liquid-fuel heating tower (`prototypes/entity/liquid-fuel-heating-tower.lua`) is a `fluid` energy source with `burns_fluid = true`, `effectivity = 3`, and a `500MW` rating. Its `fluid_usage_per_tick = 0.1` caps fluid throughput at `0.1 * 60 = 6` units/s.

For `burns_fluid = true`, the burned power is:

```
power = fluid_usage_per_tick * 60 * fuel_value * effectivity   (clamped to `consumption`)
```

So with the old cap the tower could never reach its rated 500MW with the fuels it is meant to burn:

| fuel | fuel_value | power @ 6 units/s |
|---|---|---|
| crude oil (addendum) | 1MJ | 18MW |
| liquid-rocket-fuel (primary) | 11MJ | 198MW |
| liquid-dark-matter-fuel | 72MJ | 1296MW (clamped to 500MW) |
| liquid-nuclear-fuel | 133MJ | 2394MW (clamped to 500MW) |

The primary craftable fuel (rocket fuel) tops out at 198MW, and quality tiers only raise *max* power without raising the throughput cap, so the tower never reaches its rating on its intended fuel.

## Change
Raise `fluid_usage_per_tick` from `0.1` to `0.25` (15 units/s). The file now documents the formula and reasoning inline.

| fuel | fuel_value | power @ 15 units/s |
|---|---|---|
| crude oil | 1MJ | 45MW |
| light oil | 600kJ | 27MW |
| liquid-rocket-fuel | 11MJ | 495MW (~rated) |
| liquid-dark-matter-fuel | 72MJ | clamped to 500MW |
| liquid-nuclear-fuel | 133MJ | clamped to 500MW |

This lets the tower hit its rated ~500MW on the primary refined fuel, the 500MW clamp keeps higher-energy fuels efficient (less throughput for the same output), and crude/light oil stay weak so refining remains worthwhile.

## Balance / uncertainty notes
- `0.25` was chosen so `liquid-rocket-fuel` (the cheapest *dedicated* fuel, 11MJ) lands at ~rated power: `500MW / (11MJ * 3) / 60 = 0.2525`, rounded to a clean `0.25`.
- This is a balance change; the exact number is the owner's call. If you want crude oil itself to reach rated output you would need ~`2.78`, but that would make refining pointless, which contradicts the issue's intent.
- How to verify in-game: build the tower, pipe in liquid-rocket-fuel, and confirm it sustains ~500MW heat output (was ~198MW). Confirm crude oil still under-performs.

Closes #27