### PR TITLE
Microgravity assembler pipe connections do not adhere to icons

### DIFF
--- a/prototypes/entity/gravity-assembler.lua
+++ b/prototypes/entity/gravity-assembler.lua
@@ -44,7 +44,7 @@ local building_entity =
       pipe_covers = pipecoverspictures(),
       volume = 200,
       secondary_draw_orders = { north = -1 },
-      pipe_connections = {{ flow_direction="input-output", direction = defines.direction.west, position = {-2, 1} }}
+      pipe_connections = {{ flow_direction="input", direction = defines.direction.west, position = {-2, 1} }}
     },
     {
       production_type = "input",
@@ -53,7 +53,7 @@ local building_entity =
       pipe_covers = pipecoverspictures(),
       volume = 200,
       secondary_draw_orders = { north = -1 },
-      pipe_connections = {{ flow_direction="input-output", direction = defines.direction.east, position = {2, -1} }}
+      pipe_connections = {{ flow_direction="input", direction = defines.direction.east, position = {2, -1} }}
     },
     {
       production_type = "output",
@@ -62,7 +62,7 @@ local building_entity =
       pipe_covers = pipecoverspictures(),
       volume = 100,
       secondary_draw_orders = { north = -1 },
-      pipe_connections = {{ flow_direction="input-output", direction = defines.direction.south, position = {1, 2} }}
+      pipe_connections = {{ flow_direction="output", direction = defines.direction.south, position = {1, 2} }}
     },
     {
       production_type = "output",
@@ -71,7 +71,7 @@ local building_entity =
       pipe_covers = pipecoverspictures(),
       volume = 100,
       secondary_draw_orders = { north = -1 },
-      pipe_connections = {{ flow_direction="input-output", direction = defines.direction.north, position = {-1, -2} }}
+      pipe_connections = {{ flow_direction="output", direction = defines.direction.north, position = {-1, -2} }}
     }
   },
   damaged_trigger_effect = hit_effects.entity(),


### PR DESCRIPTION
## Problem
On the microgravity assembler, fluid connections did not adhere to their icons: when running the `nanites` recipe (consumes `gray-goo`, produces `nanites` + `lubricant`), both gray-goo and lubricant could flow through every pipe connection. Reported via the mod discussion thread.

## Cause
In `prototypes/entity/gravity-assembler.lua` the four `fluid_boxes` set `production_type` correctly (two `input`, two `output`), but every `pipe_connection` used `flow_direction = "input-output"`. In Factorio 2.0 an `input-output` flow direction makes the connection bidirectional regardless of the fluid box's `production_type`, so any fluid could enter or leave through any pipe — the input and output fluid boxes effectively behaved as interconnected.

## Change
Set each connection's `flow_direction` to match its fluid box's `production_type`:
- West / East input boxes -> `flow_direction = "input"`
- South / North output boxes -> `flow_direction = "output"`

This keeps the existing positions/directions/icons untouched and simply enforces the intended one-way flow, so gray-goo can only enter on the input pipes and lubricant only exits on the output pipes.

## Balance / uncertainty notes
- No balance impact: recipe, volumes, and positions are unchanged.
- How to verify in-game: place a microgravity assembler, set the nanites recipe, pipe gray-goo into a west/east pipe and connect a separate output line to a north/south pipe. Confirm lubricant only leaves via the output pipes and gray-goo can no longer be drawn back out of any connection.

Closes #46