### PR TITLE
Mod setting to add Metal & Stars science packs to other mods' labs

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -2,6 +2,7 @@ require("__metal-and-stars__.prototypes.dependency-updates.enemy-race-manager-up
 require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 
 require("__metal-and-stars__.prototypes.dependency-updates.lab-science-updates")
+require("__metal-and-stars__.prototypes.dependency-updates.other-labs-science-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.post-pollution-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 data.raw["rocket-silo"]["rocket-silo"].fixed_recipe = nil

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -8,10 +8,12 @@ metal-and-stars=○🌐It's a big universe out there, and there are other ways t
 [mod-setting-name]
 is-nix-frozen-enabled=Nix requires heating
 is-micro-gravity-lab-all-science-enabled=Microgravity lab can process basic science
+is-science-packs-other-labs-enabled=Add Metal & Stars science packs to other labs
 
 [mod-setting-description]
 is-nix-frozen-enabled=This will make Nix require heating like Aquilo does.
 is-micro-gravity-lab-all-science-enabled=This enables the Microgravity lab to process basic science. Normally it only processes space sciences
+is-science-packs-other-labs-enabled=When enabled, the Metal & Stars science packs are added to labs from other mods, so those labs can research Metal & Stars technologies. Base game labs are unaffected.
 
 #Neumann is a surname. V is the roman numeral for 5.
 #Nix is latin for night

--- a/prototypes/dependency-updates/other-labs-science-updates.lua
+++ b/prototypes/dependency-updates/other-labs-science-updates.lua
@@ -1,0 +1,46 @@
+-- Optional compatibility: when enabled, add the Metal & Stars science packs to
+-- labs added by other mods, so those labs can research M&S technologies.
+--
+-- Base-game labs ("lab", "biolab") and the M&S microgravity lab are skipped:
+-- the microgravity lab already receives the M&S packs in lab-science-updates.lua,
+-- and the base labs are intentionally left untouched.
+
+if settings.startup["is-science-packs-other-labs-enabled"]
+    and settings.startup["is-science-packs-other-labs-enabled"].value == true then
+
+    -- Helper function to find the index of a value in a table
+    local function tableIndexOf(t, value)
+        for i, v in ipairs(t) do
+            if v == value then
+                return i
+            end
+        end
+        return nil
+    end
+
+    -- M&S science pack item names to inject into other mods' labs
+    local mas_science_packs = {
+        "nanite-science-pack",
+        "ring-science-pack",
+        "anomaly-science-pack",
+        "quantum-science-pack",
+    }
+
+    -- Labs we should NOT touch: base-game labs and the M&S microgravity lab
+    -- (the microgravity lab is handled by lab-science-updates.lua).
+    local skip_labs = {
+        ["lab"] = true,
+        ["biolab"] = true,
+        ["microgravity-lab"] = true,
+    }
+
+    for lab_name, lab in pairs(data.raw["lab"]) do
+        if not skip_labs[lab_name] and lab.inputs then
+            for _, pack in ipairs(mas_science_packs) do
+                if not tableIndexOf(lab.inputs, pack) then
+                    table.insert(lab.inputs, pack)
+                end
+            end
+        end
+    end
+end

--- a/settings.lua
+++ b/settings.lua
@@ -11,4 +11,10 @@ data:extend({
         setting_type = "startup",
         default_value = false
     },
+    {
+        type = "bool-setting",
+        name = "is-science-packs-other-labs-enabled",
+        setting_type = "startup",
+        default_value = false
+    },
 })


### PR DESCRIPTION
## Problem
Labs added by other mods cannot research Metal & Stars technologies because they don't list the M&S science packs in their `inputs`. There was no way for players to opt into cross-mod lab compatibility.

## Change
- Added a new startup bool-setting `is-science-packs-other-labs-enabled` in `settings.lua` (default **false**).
- Added `prototypes/dependency-updates/other-labs-science-updates.lua`, required from `data-updates.lua` (right after `lab-science-updates`). When the setting is enabled, it appends the four M&S science pack item names (`nanite-science-pack`, `ring-science-pack`, `anomaly-science-pack`, `quantum-science-pack`) to the `inputs` of every lab prototype except:
  - base-game labs `lab` and `biolab`
  - the M&S `microgravity-lab` (already handled in `lab-science-updates.lua`)
- A duplicate guard prevents re-adding a pack already present in a lab's `inputs`.
- Added English locale name/description for the new setting.

## Balance / uncertainty notes
- Default is **off**, so vanilla behavior is unchanged unless the player opts in.
- The skip-list excludes the two base-game lab names. If a future base/SA lab is added it would need to be added to `skip_labs`; the intent of the issue was specifically "non-base lab prototypes".
- Only the English locale string was added (mirroring how new strings are introduced before translation passes); other locales fall back to English.

To verify in-game: enable the setting with another mod that adds a lab, load a save, and confirm the modded lab accepts the four M&S science packs while the vanilla lab/biolab do not.

Closes #36