### PR TITLE
Add setting to allow armoured biters off Circa

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -8,10 +8,12 @@ metal-and-stars=○🌐It's a big universe out there, and there are other ways t
 [mod-setting-name]
 is-nix-frozen-enabled=Nix requires heating
 is-micro-gravity-lab-all-science-enabled=Microgravity lab can process basic science
+armoured-biters-circa-only=Armoured biters only on Circa
 
 [mod-setting-description]
 is-nix-frozen-enabled=This will make Nix require heating like Aquilo does.
 is-micro-gravity-lab-all-science-enabled=This enables the Microgravity lab to process basic science. Normally it only processes space sciences
+armoured-biters-circa-only=When enabled (default), armoured biters are confined to Circa (the ringworld). Disable this to let them spawn on Nauvis and other planets using the ArmouredBiters mod's default placement. Requires a new map/surface to take effect.
 
 #Neumann is a surname. V is the roman numeral for 5.
 #Nix is latin for night

--- a/prototypes/dependency-updates/armoured-biter-updates.lua
+++ b/prototypes/dependency-updates/armoured-biter-updates.lua
@@ -29,4 +29,11 @@ data:extend({
     },
 })
 
-data.raw["unit-spawner"]["armoured-biter-spawner"].autoplace = {probability_expression = "ringworld_snapper_enemy_base_probability", force = "ringworld_snappers"}
+-- By default Metal and Stars confines armoured biters to Circa (the ringworld) by
+-- replacing their autoplace with a ringworld-only probability expression. This stops
+-- them spawning on Nauvis / other planets, where the base ArmouredBiters mod would
+-- otherwise place them. The "armoured-biters-circa-only" startup setting lets players
+-- opt out and keep the mod's default (Nauvis-wide) autoplace.
+if settings.startup["armoured-biters-circa-only"].value then
+    data.raw["unit-spawner"]["armoured-biter-spawner"].autoplace = {probability_expression = "ringworld_snapper_enemy_base_probability", force = "ringworld_snappers"}
+end

--- a/prototypes/dependency-updates/enemy-race-manager-updates.lua
+++ b/prototypes/dependency-updates/enemy-race-manager-updates.lua
@@ -1,5 +1,11 @@
 if mods["enemyracemanager"] then
-   data.raw["unit-spawner"]["enemy--armoured-biter-spawner--1"].autoplace = {probability_expression ="ringworld_snapper_enemy_base_probability", force = "ringworld_snappers"}
+   -- Only confine the Enemy Race Manager variant of the armoured biter spawner to
+   -- Circa when the "armoured-biters-circa-only" startup setting is enabled. When it
+   -- is disabled we leave its default autoplace intact so it can spawn on Nauvis /
+   -- other planets.
+   if settings.startup["armoured-biters-circa-only"].value then
+      data.raw["unit-spawner"]["enemy--armoured-biter-spawner--1"].autoplace = {probability_expression ="ringworld_snapper_enemy_base_probability", force = "ringworld_snappers"}
+   end
 
    local ringworld_map_settings = data.raw.planet.ringworld.map_gen_settings
    ringworld_map_settings.autoplace_settings.entity.settings["armoured-biter-spawner"] = nil

--- a/settings.lua
+++ b/settings.lua
@@ -11,4 +11,11 @@ data:extend({
         setting_type = "startup",
         default_value = false
     },
+    {
+        type = "bool-setting",
+        name = "armoured-biters-circa-only",
+        setting_type = "startup",
+        default_value = true,
+        order = "a-z"
+    },
 })


### PR DESCRIPTION
## Problem

The mod confines armoured biters to **Circa** (the ringworld), preventing them from spawning on Nauvis or other planets. Reported via the mod portal discussion (linked in the issue), where a player asked for a setting to control it.

The restriction comes from two places that **completely overwrite** the armoured-biter-spawner's `autoplace` with a ringworld-only probability expression (`ringworld_snapper_enemy_base_probability`, gated by `ringworld_left_mask` / `aquilo_starting_mask`):

- `prototypes/dependency-updates/armoured-biter-updates.lua` (`armoured-biter-spawner`)
- `prototypes/dependency-updates/enemy-race-manager-updates.lua` (`enemy--armoured-biter-spawner--1`, when Enemy Race Manager is present)

Because this replaces the base ArmouredBiters mod's default autoplace, the biters can no longer spawn anywhere except Circa.

## Change

- Add a new startup bool-setting `armoured-biters-circa-only` (default **true**, preserving current behavior).
- Guard both autoplace overrides behind this setting. When disabled, the Circa-only override is skipped, leaving the ArmouredBiters mod's default (Nauvis-wide) autoplace intact.
- Add `en` locale entries for the setting name/description.

The Circa autoplace-control + noise-expression prototypes are left untouched, so Circa's spawning logic is unaffected; only the per-spawner override is conditional now.

## Balance / uncertainty notes

- Default is unchanged (Circa-only), so existing saves and the intended Circa experience are preserved. Players must opt in to off-Circa spawns.
- Startup setting -> takes effect on new maps/surfaces; existing chunks already generated won't retroactively gain biters.
- Uncertain: the exact default autoplace the base ArmouredBiters mod provides for `armoured-biter-spawner` when we *don't* override it. I expect it mirrors vanilla biter placement (Nauvis), but this should be confirmed in-game.

## How to verify in-game

1. Enable the ArmouredBiters mod alongside Metal and Stars.
2. In mod settings (Startup), uncheck "Armoured biters only on Circa".
3. Start a new Nauvis game with enemies enabled and confirm armoured biter nests generate on Nauvis. Re-enable to confirm they are confined to Circa again.
4. If Enemy Race Manager is installed, repeat to confirm the `enemy--armoured-biter-spawner--1` variant behaves the same.

Closes #43