### PR TITLE
Neumann V: nanite rocket silo so the planet is escapable

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -371,6 +371,7 @@ canister-liquid-dark-matter-fuel=Canister liquid dark matter fuel
 nano-rocket-part=Nano rocket part
 ring-rocket-part=Ring rocket part
 anomalous-rocket-part=Anomalous rocket part
+nanite-rocket-silo=Nanite rocket silo
 
 [tile-name]
 snow-patchy-grass=Snowy grass

--- a/prototypes/planet/technology-basic.lua
+++ b/prototypes/planet/technology-basic.lua
@@ -140,6 +140,10 @@ data:extend({
                 type = "unlock-recipe",
                 recipe = "nano-rocket-part"
             },
+            {
+                type = "unlock-recipe",
+                recipe = "nanite-rocket-silo"
+            },
         },
         prerequisites = {"nanite-extraction"},
         research_trigger =

--- a/prototypes/recipes-rocket-parts.lua
+++ b/prototypes/recipes-rocket-parts.lua
@@ -65,4 +65,24 @@ data:extend({
         allow_productivity = true,
         auto_recycle = false,
     },
+    -- Nanite-assembled rocket silo so players who arrive on Neumann V (shipyard)
+    -- empty-handed can still bootstrap an exit. Crafts in the microgravity
+    -- assembler (nanotech category) once nanite-rocket-construction is researched.
+    {
+        type = "recipe",
+        name = "nanite-rocket-silo",
+        icon = "__base__/graphics/icons/rocket-silo.png",
+        energy_required = 60,
+        enabled = false,
+        category = "nanotech",
+        subgroup = "space-nanites",
+        order = "c[lithium]-c[rocket-silo]",
+        ingredients =
+        {
+            {type = "item", name = "nanites", amount = 1000},
+        },
+        results = {{type="item", name="rocket-silo", amount=1}},
+        allow_productivity = false,
+        auto_recycle = false,
+    },
 })


### PR DESCRIPTION
## Problem
Players who complete the nanite science path on Neumann V (the shipyard planet) currently **cannot leave**. There is no nanite-based rocket-silo recipe, and shipping a fully-built silo in from another planet is impractical. Arriving empty-handed becomes a dead end.

## Change
Adds a `nanite-rocket-silo` recipe:
- **Ingredients:** 1000 nanites -> 1 `rocket-silo`
- **Category:** `nanotech` (crafts in the microgravity assembler, like the other nano-* entity recipes such as `nanothruster`/`nanograbber`/`nanocrusher`)
- **Unlocked by:** the existing `nanite-rocket-construction` technology, right alongside `nano-rocket-part` — so once you can build rocket parts from nanites, you can also build the silo to fire them out of.
- `productivity` disabled (entity recipe, consistent with the other nano entity recipes), `auto_recycle = false`.

This gives players a guaranteed bootstrap-an-exit path purely from nanites/gray-goo, mirroring how a rocket silo bootstraps the exit from Nauvis.

Files:
- `prototypes/recipes-rocket-parts.lua` — new recipe
- `prototypes/planet/technology-basic.lua` — unlock on `nanite-rocket-construction`
- `locale/en/locale.cfg` — recipe name

## Balance / uncertainty notes
- 1000 nanites is a placeholder cost chosen to feel like a significant late-shipyard investment (nanites are produced 50 at a time from 50 gray-goo). Easy to tune.
- I deliberately reused the existing `nanite-rocket-construction` tech rather than adding a new one, to keep the tree minimal. If reviewers prefer a dedicated tech/research-trigger, that is a one-line move.
- The issue also mentions an alternative: a scrap-like "garbage" entity yielding iron plates. I implemented the nanite-silo route since it is self-contained and directly fixes the "can't leave" blocker; the iron-garbage idea can be a follow-up if desired.
- **How to verify in-game:** on the shipyard, research `nanite-rocket-construction`, place a microgravity assembler, set the "Nanite rocket silo" recipe, feed it nanites, and confirm it outputs a placeable rocket silo that can then build/launch rockets (silo `fixed_recipe` is already cleared in this file so the nano rocket-part recipes apply).

Closes #32