### PR TITLE
Allow quality for the new flying robots

### DIFF
--- a/prototypes/dependency-updates/quality-updates.lua
+++ b/prototypes/dependency-updates/quality-updates.lua
@@ -10,4 +10,13 @@ if mods["quality"] then
     if data.raw["technology"]["module-productivity-advanced"] ~= nil then
         table.insert(data.raw["technology"]["module-productivity-advanced"].effects,   {type = "change-recipe-productivity", recipe = "quality-module-3", change = 0.1})
     end
+
+    -- Allow quality for the new flying robots (antimatter logistic/construction robots).
+    -- Explicitly opt the recipes in so the robots can be crafted at higher qualities.
+    for _, recipe_name in pairs({"antimatter-logistic-robot", "antimatter-construction-robot"}) do
+        local recipe = data.raw["recipe"][recipe_name]
+        if recipe ~= nil then
+            recipe.allow_quality = true
+        end
+    end
 end


### PR DESCRIPTION
## Problem
The new flying robots (`antimatter-logistic-robot` and `antimatter-construction-robot`) should support quality, but the intent was never made explicit. The issue asks to ensure quality is not disabled for these robots and that they are handled in the quality-update logic.

## Change
Added an explicit opt-in in `prototypes/dependency-updates/quality-updates.lua` (already gated behind `mods["quality"]`) that sets `allow_quality = true` on the two robot recipes:

- `antimatter-logistic-robot`
- `antimatter-construction-robot`

The recipes did not set `allow_quality = false` and the items are not in any exclusion list, so this makes the quality support explicit and robust against any default or cross-mod changes. The loop nil-checks each recipe before touching it.

## Balance / uncertainty notes
- No balance change: this only allows the robots to be produced at higher qualities, like vanilla robots.
- The runtime placement logic in `lib/control-stage.lua` already preserves `entity.quality`, so picked-up/placed robots keep their quality.

## How to verify in-game
1. Start a Space Age save with the Quality mod enabled.
2. Research the antimatter robots tech and craft the robots in a quality-capable assembler (with quality modules).
3. Confirm higher-quality `antimatter-logistic-robot` / `antimatter-construction-robot` variants can be produced and placed.

Closes #35