### PR TITLE
Circa: add a calcite sink (calcite calcination)

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -322,6 +322,7 @@ multilayer-insulation=Multilayer insulation
 aspheric-lens=Aspheric lens
 process-bitumen=Process bitumen
 bone-to-calcite=Bone to calcite
+calcite-calcination=Calcite calcination
 ring-science-pack=Ring science pack
 high-speed-processor=High-speed processor
 overclock-module=Overclock module

--- a/prototypes/planet/technology-basic.lua
+++ b/prototypes/planet/technology-basic.lua
@@ -411,6 +411,10 @@ data:extend({
             type = "unlock-recipe",
             recipe = "bone-to-calcite"
           },
+          {
+            type = "unlock-recipe",
+            recipe = "calcite-calcination"
+          },
         },
         prerequisites = {"planet-discovery-ringworld"},
         research_trigger =

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -860,6 +860,26 @@ data:extend({
     enabled = false
   },
   {
+    -- Calcite sink for Circa: players arrive here before Vulcanus/Fulgora and
+    -- have no way to dispose of excess calcite (Acid Neutralization is
+    -- Vulcanus-only, recyclers need Fulgora tech). Calcining calcite drives off
+    -- CO2 and leaves a stony residue, giving a small-loss productive sink that
+    -- yields stone (useful for landfill/concrete) instead of a pure void.
+    type = "recipe",
+    name = "calcite-calcination",
+    category = "smelting",
+    subgroup = "ringworld-processes",
+    order = "c[lithium]-c[calcite-calcination]",
+    energy_required = 3.2,
+    ingredients = {
+      {type = "item", name = "calcite", amount = 5},
+    },
+    results = {{type="item", name="stone", amount=2}},
+    allow_productivity = true,
+    auto_recycle = false,
+    enabled = false
+  },
+  {
     type = "recipe",
     name = "ring-science-pack",
     category = "crafting-with-fluid",


### PR DESCRIPTION
## Problem
Circa's bitumen/tar processing produces Bone Fragments, which convert to Calcite via `bone-to-calcite`. Players reach Circa **before** Vulcanus and Fulgora, so they have **no sink for excess calcite**: Acid Neutralization is Vulcanus-only, and recyclers require Fulgora tech. Excess calcite just piles up. (Issue #29)

## Change
Add a Circa-available calcite sink: a new `calcite-calcination` smelting recipe (**5 calcite -> 2 stone**), unlocked alongside `bone-to-calcite` by the existing `bitumen-processing` technology. The recipe is available the moment a player can make calcite on Circa, and it produces stone (useful for landfill/concrete) rather than being a pure void, so it is a small-loss *productive* sink rather than a trash can.

Files touched:
- `prototypes/recipe.lua` - new `calcite-calcination` recipe (smelting, `ringworld-processes` subgroup, productivity-allowed; icon auto-derives from the single stone product).
- `prototypes/planet/technology-basic.lua` - unlock added to `bitumen-processing`.
- `locale/en/locale.cfg` - recipe name string.

## Balance / uncertainty notes
- Ratio (5:2 calcite->stone) is a deliberate loss so the sink is for *excess*, not a stone factory. Tune freely.
- I chose **a sink recipe** over the alternative of **gating Circa behind Metallurgic/Fulgora science** (which would expose the existing Acid Neutralization / recycler sinks). Gating would be a larger progression change and would push Circa later than its current `nanite-science-pack` prerequisite; the local recipe is the minimal, non-disruptive fix. If maintainers prefer the gating route instead, this PR is easy to revert.
- The issue also mentions revisiting **heavy-water balance** from the same thread; that is a separate concern and is intentionally **not** addressed here to keep this PR focused.

## How to verify in-game
1. Travel to Circa (ringworld), research `bitumen-processing` (mine ringworld-detritus trigger).
2. Confirm both `Bone to calcite` and the new `Calcite calcination` recipes are unlocked.
3. Build a furnace, set it to `Calcite calcination`, feed calcite, confirm it consumes 5 calcite and outputs 2 stone.

Refs #29 (calcite sink only; the heavy-water rebalance from the issue is intentionally not addressed here)
