### PR TITLE
Krastorio 2: Empty Liquid Nuclear Fuel exploit

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -2,6 +2,7 @@ require("__metal-and-stars__.prototypes.dependency-updates.enemy-race-manager-up
 require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 
 require("__metal-and-stars__.prototypes.dependency-updates.lab-science-updates")
+require("__metal-and-stars__.prototypes.dependency-updates.krastorio2-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.post-pollution-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 data.raw["rocket-silo"]["rocket-silo"].fixed_recipe = nil

--- a/prototypes/dependency-updates/krastorio2-updates.lua
+++ b/prototypes/dependency-updates/krastorio2-updates.lua
@@ -1,0 +1,28 @@
+-- Krastorio 2 / Krastorio 2 Spaced Out compatibility fixes
+--
+-- Bug (issue #40): With Krastorio 2 active, K2 replaces the vanilla solid
+-- "nuclear-fuel" recipe with a much cheaper one (essentially rocket-fuel based,
+-- without the vanilla U-235 cost). Metal and Stars' "empty-liquid-nuclear-fuel"
+-- recipe then turns 1 solid nuclear-fuel into 10 liquid-nuclear-fuel (133MJ each
+-- = 1330MJ). Combined with K2's cheap nuclear-fuel this lets players generate
+-- near-free nuclear fuel/energy from rocket fuel with no uranium input.
+--
+-- Fix: when K2 is present, restore an explicit U-235 cost to the unbottling
+-- recipe so converting solid nuclear fuel into the high-energy liquid form again
+-- requires proper nuclear inputs, matching the intended (vanilla) balance of the
+-- "liquid-nuclear-fuel" production recipe (which already costs U-235).
+if mods["Krastorio2"] or mods["Krastorio2-spaced-out"] then
+    local empty_recipe = data.raw["recipe"]["empty-liquid-nuclear-fuel"]
+    if empty_recipe ~= nil and data.raw["item"]["uranium-235"] ~= nil then
+        local has_u235 = false
+        for _, ingredient in pairs(empty_recipe.ingredients) do
+            if ingredient.name == "uranium-235" then
+                has_u235 = true
+                break
+            end
+        end
+        if not has_u235 then
+            table.insert(empty_recipe.ingredients, {type = "item", name = "uranium-235", amount = 1})
+        end
+    end
+end

--- a/prototypes/dependency-updates/krastorio2-updates.lua
+++ b/prototypes/dependency-updates/krastorio2-updates.lua
@@ -13,7 +13,7 @@
 -- "liquid-nuclear-fuel" production recipe (which already costs U-235).
 if mods["Krastorio2"] or mods["Krastorio2-spaced-out"] then
     local empty_recipe = data.raw["recipe"]["empty-liquid-nuclear-fuel"]
-    if empty_recipe ~= nil and data.raw["item"]["uranium-235"] ~= nil then
+    if empty_recipe ~= nil and empty_recipe.ingredients ~= nil and data.raw["item"]["uranium-235"] ~= nil then
         local has_u235 = false
         for _, ingredient in pairs(empty_recipe.ingredients) do
             if ingredient.name == "uranium-235" then


### PR DESCRIPTION
## Problem

With **Krastorio 2 / K2 Spaced Out** active, the `empty-liquid-nuclear-fuel` recipe lets players make near-free nuclear fuel/energy from rocket fuel (reported in issue #40 on Factorio 2.0.69, K2SO 1.4.27, M&S 0.1.17).

Root cause: K2 replaces the vanilla solid `nuclear-fuel` recipe with a much cheaper, essentially rocket-fuel-based recipe that drops the vanilla U-235 cost. Metal and Stars' `empty-liquid-nuclear-fuel` recipe then converts **1 solid nuclear-fuel into 10 `liquid-nuclear-fuel`** (133MJ each = 1330MJ) with no other inputs. In vanilla this is roughly balanced because solid nuclear fuel is expensive (U-235 + rocket fuel), but under K2 the cheap nuclear fuel makes the liquid conversion a free energy multiplier.

## Change

Adds a new K2-guarded compatibility file `prototypes/dependency-updates/krastorio2-updates.lua` (required from `data-updates.lua`, matching the existing `*-updates.lua` pattern). When `mods["Krastorio2"]` or `mods["Krastorio2-spaced-out"]` is present, it restores an explicit `uranium-235` (amount 1) ingredient to the `empty-liquid-nuclear-fuel` recipe. This mirrors the uranium cost already required by the `liquid-nuclear-fuel` production recipe, so the unbottling path can no longer be a cheap workaround.

The change is fully guarded behind the K2 mod check and is idempotent (skips if U-235 is already an ingredient), so vanilla and non-K2 setups are unaffected.

## Balance / uncertainty notes

- Adds 1 U-235 per `empty-liquid-nuclear-fuel` craft under K2; this is intentionally conservative and matches the existing `liquid-nuclear-fuel` recipe's uranium input. The exact amount can be tuned if reviewers prefer a different uranium cost.
- I could not launch Factorio with K2SO to verify in-game. To verify: with K2/K2SO + M&S, research Kovarex Enrichment and confirm the "Empty liquid nuclear fuel" recipe now lists uranium-235 as an input, and that the rocket-fuel -> liquid-nuclear-fuel energy arbitrage is no longer free.
- No `changelog.txt` edit (avoids cross-PR conflicts).

Closes #40