### PR TITLE
Rocket part fix: adopt PlanetsLib 1.13.1 mod-data for alternative rocket silos

### DIFF
--- a/prototypes/recipes-rocket-parts.lua
+++ b/prototypes/recipes-rocket-parts.lua
@@ -2,6 +2,25 @@
 data.raw["rocket-silo"]["rocket-silo"].fixed_recipe = nil
 data.raw.recipe["rocket-part"].order = "b[rocket-part]-a[vanilla]"
 
+-- PlanetsLib 1.13.1+ integration.
+-- PlanetsLib added the "Planetslib-planet-lock-rocket-silos" mod-data prototype, which
+-- controls whether vanilla-style rocket silos have their recipe locked when placed
+-- (PlanetsLib's runtime handler calls entity.set_recipe(...) + recipe_locked = true).
+-- For surfaces not explicitly listed, PlanetsLib uses the "default" entry, which defaults
+-- to `true`. That locking prevents Metal and Stars' alternative, player-selectable
+-- rocket-part recipes (nano/ring/anomalous, gated by tech + surface_conditions) from being
+-- chosen in a silo.
+-- Per PlanetsLib's own guidance ("Mods that add new optional rocket part recipes should set
+-- the default to false."), we flip the global default lock to false so silos placed on
+-- M&S (and other) surfaces remain unlocked and let the player pick the appropriate recipe.
+-- Guarded so the mod still loads against PlanetsLib < 1.13.1 (where the prototype is absent).
+do
+    local lock_silo_data = data.raw["mod-data"] and data.raw["mod-data"]["Planetslib-planet-lock-rocket-silos"]
+    if lock_silo_data and lock_silo_data.data then
+        lock_silo_data.data.default = false
+    end
+end
+
 data:extend({
     {
         type = "recipe",


### PR DESCRIPTION
## Problem

PlanetsLib historically prevented alternative rocket-silo recipes (like Metal and Stars') from working. As of **PlanetsLib 1.13.1**, this is now configurable via a `mod-data` prototype.

PlanetsLib's runtime handler (`scripts/rocket-parts.lua`, registered on `on_built_entity` for rocket silos) sets a vanilla-style silo's recipe and locks it when it is placed:

```lua
entity.set_recipe(recipe)            -- from "Planetslib-planet-rocket-part-recipe"
entity.recipe_locked = lock_silo     -- from "Planetslib-planet-lock-rocket-silos"
```

Both values come from a per-surface entry, falling back to a `default` entry. The lock default is `true`. On M&S surfaces (which are not explicitly listed) the silo therefore gets `rocket-part` set and `recipe_locked = true`, which blocks M&S's optional, player-selectable rocket-part recipes (`nano-rocket-part`, `ring-rocket-part`, `anomalous-rocket-part`) that are gated by tech + `surface_conditions`.

## Change

PlanetsLib's own `prototypes/mod-data.lua` documents the intended hook:

> `default = true` -- Used for surfaces not specified. **Mods that add new optional rocket part recipes should set the default to false.**

So in `prototypes/recipes-rocket-parts.lua` we now flip the global lock default to `false`:

```lua
data.raw["mod-data"]["Planetslib-planet-lock-rocket-silos"].data.default = false
```

The write is guarded (existence check on `data.raw["mod-data"]` and the prototype) so the mod still loads cleanly against PlanetsLib **< 1.13.1**, where the prototype does not exist. Load order is safe: PlanetsLib is a declared dependency and creates this prototype in its own `data.lua`, which runs before M&S's `data.lua` (where `recipes-rocket-parts.lua` is required).

This is the data-stage, version-aware replacement for the brittle runtime `recipe_locked = false` workaround in `prototypes/dependency-updates/compatibility-scripts.lua`; that runtime handler is left in place as a harmless fallback for older PlanetsLib versions and is not touched here.

## Balance / behavior notes

- Setting only the *lock* default to `false` (not the *recipe* default) means PlanetsLib still calls `entity.set_recipe("rocket-part")` on placement, but leaves the silo unlocked so the player can immediately switch to a researched M&S recipe. This preserves M&S's existing "many optional recipes" design rather than forcing one recipe per planet.
- This changes the global default, affecting silos on all surfaces (including Nauvis/vanilla). Because M&S already cleared `fixed_recipe` and unlocked silos via `compatibility-scripts.lua`, this matches existing M&S behavior; it does not lock anything that was previously unlocked.

## What I tried / what's uncertain / how to verify in-game

Verified against the locally-installed PlanetsLib (1.18.0): confirmed the prototype name (`Planetslib-planet-lock-rocket-silos`), its `data.default = true`, the runtime read path in `scripts/rocket-parts.lua`, and the 1.13.1 changelog feature note. The exact prototype name and default have been stable since 1.13.1.

Uncertain (could not launch the game here):
- Whether any specific M&S surface should instead get an explicit per-surface recipe via `PlanetsLib.assign_rocket_part_recipe(surface, recipe, false)` rather than relying on the global default. If a per-planet fixed rocket-part recipe is ever desired, that API is the follow-up.

To verify in-game:
1. With PlanetsLib >= 1.13.1 installed, research one of the M&S rocket-part techs (e.g. nanite rocket construction).
2. Place a rocket silo on an M&S surface and confirm its recipe is **not** locked and that the researched M&S rocket-part recipe (e.g. `nano-rocket-part`) can be selected and crafted.
3. Confirm Nauvis/vanilla silos still behave normally.
4. Load with PlanetsLib < 1.13.1 to confirm no startup error (guarded path).

Closes #41