### PR TITLE
Rename medium-equipment-grid to MSMS-grid

### DIFF
--- a/migrations/16-jun-26.json
+++ b/migrations/16-jun-26.json
@@ -1,0 +1,6 @@
+{
+    "equipment-grid":
+    [
+      ["medium-equipment-grid", "MSMS-grid"]
+    ]
+  }

--- a/prototypes/entity/prototype-mech-armor.lua
+++ b/prototypes/entity/prototype-mech-armor.lua
@@ -1,6 +1,16 @@
 local item_sounds = require("__base__.prototypes.item_sounds")
 local simulations = require("__space-age__.prototypes.factoriopedia-simulations")
 
+-- Define a mod-prefixed equipment grid (MSMS = MetalStarsMechSuit) instead of
+-- reusing the generic vanilla "medium-equipment-grid", whose shared name collides
+-- with other mods that reference/modify the same grid. We deep-copy the vanilla
+-- medium grid so width/height/equipment_categories stay identical, then rename it.
+local msms_grid = table.deepcopy(data.raw["equipment-grid"]["medium-equipment-grid"])
+msms_grid.name = "MSMS-grid"
+msms_grid.localised_name = nil
+msms_grid.localised_description = nil
+data:extend({ msms_grid })
+
 data:extend({
   {
     type = "armor",
@@ -37,7 +47,7 @@ data:extend({
     drop_sound = item_sounds.armor_large_inventory_move,
     stack_size = 1,
     infinite = true,
-    equipment_grid = "medium-equipment-grid",
+    equipment_grid = "MSMS-grid",
     inventory_size_bonus = 50,
     provides_flight = true,
     takeoff_sound = {filename = "__space-age__/sound/entity/mech-armor/mech-armor-takeoff.ogg", volume = 0.2, aggregation = {max_count = 2, remove = true, count_already_playing = true}},


### PR DESCRIPTION
## Problem
The mech armor (`prototypes/entity/prototype-mech-armor.lua`) reused the generic vanilla equipment grid `medium-equipment-grid`. That shared, unprefixed name collides with other mods that reference or modify the same grid, causing compatibility issues (reported at https://mods.factorio.com/mod/metal-and-stars/discussion/6902c96c6a639e3cbed811d1).

## Change
- Define a mod-prefixed equipment grid `MSMS-grid` (MetalStarsMechSuit) by deep-copying the vanilla `medium-equipment-grid` at the data stage, so `width` / `height` / `equipment_categories` stay byte-for-byte identical. Only the name changes.
- Point `prototype-mech-armor`'s `equipment_grid` at `MSMS-grid`.
- Add `migrations/16-jun-26.json` with an `equipment-grid` remap (`medium-equipment-grid` -> `MSMS-grid`) so equipment grids already attached to mech armor in existing saves are remapped on load.

## Save compatibility
Equipment grids attach to armor at runtime, so the rename needs the migration to avoid losing installed equipment on existing saves. The migration's `equipment-grid` section handles that remap. Behavior is unchanged because the new grid is a verbatim copy of the vanilla medium grid.

## Notes / how to verify in-game
- No locale entry was added: the mech armor previously borrowed vanilla's grid (and its vanilla locale); equipment grids don't surface a name to the player. The deep-copy clears `localised_name`/`localised_description` so the new prototype falls back cleanly.
- Verify: load a pre-existing save that has mech armor with installed equipment — equipment should remain in place under the renamed `MSMS-grid`. On a fresh game, the mech armor grid should have the same size and accepted equipment categories as before.

Closes #39