### PR TITLE
[investigation] Grow Lignum trees on the left side of Circa

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -4,6 +4,7 @@ require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.lab-science-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.post-pollution-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
+require("__metal-and-stars__.prototypes.dependency-updates.lignumis-updates")
 data.raw["rocket-silo"]["rocket-silo"].fixed_recipe = nil
 table.insert(data.raw.item.foundation.place_as_tile.tile_condition, "gray-goo-tile")
 

--- a/info.json
+++ b/info.json
@@ -24,7 +24,8 @@
     "(?) planet-muluna",
     "(?) Cerys-Moon-of-Fulgora",
     "(?) enemyracemanager",
-    "(?) Redrawn-Space-Connections"
+    "(?) Redrawn-Space-Connections",
+    "(?) lignumis"
   ],
   "space_travel_required": true,
   "spoiling_required": true,

--- a/prototypes/dependency-updates/lignumis-updates.lua
+++ b/prototypes/dependency-updates/lignumis-updates.lua
@@ -2,45 +2,81 @@
 --
 -- Circa (the "ringworld" planet) is split down the middle: the LEFT side (x < 0) is the
 -- overgrown / undergrowth biome, the RIGHT side (x > 0) is the desert. We reuse the existing
--- "ringworld_left_mask" noise expression so the trees only appear in the danger zone on the
--- left side, matching the thematic overgrowth there.
+-- "ringworld_left_mask" noise expression (defined in ringworld_tiles.lua) so the trees only
+-- appear in the overgrown danger zone on the left side, matching the thematic undergrowth there.
 --
--- NOTE / UNCERTAINTY: the internal name of the Lignumis tree entity is not 100% confirmed from
--- the mod source, so we probe a list of candidate names and only act if one actually exists.
--- This keeps the change safe (no crash, no-op) if the assumed name is wrong. If Circa shows no
--- Lignum trees in-game, update "candidate_tree_names" below with the correct entity name.
+-- IMPORTANT: in Lignumis the wood tree is a PLANT prototype at data.raw.plant["tree-plant"]
+-- (type "plant"), NOT a data.raw["tree"]. We must not mutate that shared prototype in place,
+-- because it is the same object used to generate trees on the Lignumis planet itself; editing
+-- its autoplace would also alter Lignumis. Instead we table.deepcopy it into a brand new plant
+-- prototype with a distinct name ("circa-lignum-tree"), give the COPY a Circa-specific autoplace,
+-- and data:extend it. The original Lignumis tree-plant is left untouched.
+--
+-- NOTE / UNCERTAINTY: the Circa autoplace below mirrors the in-mod precedent for placing entities
+-- on the undergrowth biome (see prototypes/entity/resources.lua "ringworld-detritus": a bare
+-- probability_expression + tile_restriction registered under autoplace_settings.entity). We reuse
+-- "ringworld_left_mask" and restrict to the four undergrowth tiles so the trees only spawn on the
+-- left overgrowth. We deliberately do NOT use a "trees" autoplace_control because ringworld's
+-- map_gen (ringworld_map_gen.lua) only defines ringworld_* controls and has no "trees" control;
+-- referencing a missing control would be invalid. If the exact density/look needs tuning, adjust
+-- the probability multiplier or tile_restriction below.
 
 if mods["lignumis"] then
-    if data.raw.planet and data.raw.planet.ringworld then
-        local ringworld_map_settings = data.raw.planet.ringworld.map_gen_settings
+    if data.raw.planet and data.raw.planet.ringworld and data.raw.plant then
+        local source_tree = data.raw.plant["tree-plant"]
+        local ringworld_planet = data.raw.planet.ringworld
+        local ringworld_map_settings = ringworld_planet.map_gen_settings
 
-        -- Candidate internal names for the Lignumis wood tree entity, most-likely first.
-        local candidate_tree_names =
-        {
-            "wood-tree",
-            "lignumis-tree",
-            "tree-lignumis",
-            "lignum-tree",
-        }
+        -- Confirm the Lignumis tree-plant exists and that ringworld exposes the expected
+        -- autoplace_settings.entity table and the ringworld_left_mask noise expression. If any of
+        -- these is absent, do nothing (clean no-op, no crash).
+        local left_mask_present = false
+        if data.raw["noise-expression"] and data.raw["noise-expression"]["ringworld_left_mask"] then
+            left_mask_present = true
+        end
 
-        local trees = data.raw["tree"] or {}
+        if source_tree
+            and ringworld_map_settings
+            and ringworld_map_settings.autoplace_settings
+            and ringworld_map_settings.autoplace_settings.entity
+            and ringworld_map_settings.autoplace_settings.entity.settings
+            and left_mask_present
+        then
+            local circa_tree_name = "circa-lignum-tree"
 
-        for _, tree_name in ipairs(candidate_tree_names) do
-            local tree = trees[tree_name]
-            if tree then
-                -- Place the tree only on the left/west side of Circa, in the danger zone.
-                -- ringworld_left_mask = (x < 0) * ringworld_danger_mask, defined in ringworld_tiles.lua.
-                tree.autoplace =
+            -- Only create the copy once (guard against double data:extend if this file is required
+            -- more than once during the data stage).
+            if not data.raw.plant[circa_tree_name] then
+                local circa_tree = table.deepcopy(source_tree)
+                circa_tree.name = circa_tree_name
+
+                -- Some prototypes carry a minable result / autoplace control referencing the
+                -- original; clear the control so we do not depend on a (non-existent on Circa)
+                -- "trees" autoplace_control, and give the copy a Circa-specific autoplace that
+                -- mirrors the in-mod undergrowth placement pattern.
+                circa_tree.autoplace =
                 {
-                    control = "trees",
                     order = "a[tree]-b[forest]-a[lignumis]",
+                    -- ringworld_left_mask = (x < 0) * ringworld_danger_mask (ringworld_tiles.lua).
                     probability_expression = "ringworld_left_mask * 0.4",
-                    richness_expression = "clamp(random_penalty_at(6, 1), 0, 1)",
+                    richness_expression = "ringworld_left_mask",
+                    -- Restrict to Circa's left-side overgrowth tiles so the trees grow in the
+                    -- undergrowth biome (these tiles are defined in ringworld_tiles.lua).
+                    tile_restriction =
+                    {
+                        "undergrowth-thin",
+                        "undergrowth-thin-dark",
+                        "undergrowth-thick",
+                        "undergrowth-thick-dark",
+                    },
                 }
 
-                -- Register the tree in Circa's autoplace settings so it actually generates there.
-                ringworld_map_settings.autoplace_settings.entity.settings[tree_name] = {}
+                data:extend({ circa_tree })
             end
+
+            -- Register the NEW Circa tree (not the shared Lignumis tree) in Circa's autoplace
+            -- settings so it actually generates there. Plants register under the "entity" category.
+            ringworld_map_settings.autoplace_settings.entity.settings[circa_tree_name] = {}
         end
     end
 end

--- a/prototypes/dependency-updates/lignumis-updates.lua
+++ b/prototypes/dependency-updates/lignumis-updates.lua
@@ -1,0 +1,46 @@
+-- Lignumis compatibility: grow Lignum (Lignumis) trees on the left/west side of Circa.
+--
+-- Circa (the "ringworld" planet) is split down the middle: the LEFT side (x < 0) is the
+-- overgrown / undergrowth biome, the RIGHT side (x > 0) is the desert. We reuse the existing
+-- "ringworld_left_mask" noise expression so the trees only appear in the danger zone on the
+-- left side, matching the thematic overgrowth there.
+--
+-- NOTE / UNCERTAINTY: the internal name of the Lignumis tree entity is not 100% confirmed from
+-- the mod source, so we probe a list of candidate names and only act if one actually exists.
+-- This keeps the change safe (no crash, no-op) if the assumed name is wrong. If Circa shows no
+-- Lignum trees in-game, update "candidate_tree_names" below with the correct entity name.
+
+if mods["lignumis"] then
+    if data.raw.planet and data.raw.planet.ringworld then
+        local ringworld_map_settings = data.raw.planet.ringworld.map_gen_settings
+
+        -- Candidate internal names for the Lignumis wood tree entity, most-likely first.
+        local candidate_tree_names =
+        {
+            "wood-tree",
+            "lignumis-tree",
+            "tree-lignumis",
+            "lignum-tree",
+        }
+
+        local trees = data.raw["tree"] or {}
+
+        for _, tree_name in ipairs(candidate_tree_names) do
+            local tree = trees[tree_name]
+            if tree then
+                -- Place the tree only on the left/west side of Circa, in the danger zone.
+                -- ringworld_left_mask = (x < 0) * ringworld_danger_mask, defined in ringworld_tiles.lua.
+                tree.autoplace =
+                {
+                    control = "trees",
+                    order = "a[tree]-b[forest]-a[lignumis]",
+                    probability_expression = "ringworld_left_mask * 0.4",
+                    richness_expression = "clamp(random_penalty_at(6, 1), 0, 1)",
+                }
+
+                -- Register the tree in Circa's autoplace settings so it actually generates there.
+                ringworld_map_settings.autoplace_settings.entity.settings[tree_name] = {}
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Problem
Issue #38 asks for Lignum (Lignumis) trees to autoplace/grow on the **left/west side of Circa** (the `ringworld` planet) for thematic tree coverage and harvesting.

## Change
Adds `prototypes/dependency-updates/lignumis-updates.lua`, gated on `mods["lignumis"]`, required from `data-updates.lua` (so it runs after Lignumis' prototypes exist). When the mod is present it:

- Reuses the existing `ringworld_left_mask` noise expression (`(x < 0) * ringworld_danger_mask`, defined in `ringworld_tiles.lua`) so trees only generate on the left/overgrowth half of Circa.
- Sets the Lignumis tree's `autoplace` (`probability_expression = "ringworld_left_mask * 0.4"`) and registers the tree in `data.raw.planet.ringworld.map_gen_settings.autoplace_settings.entity.settings`, mirroring the existing enemy-race-manager compat pattern.

Also adds `(?) lignumis` as a hidden optional dependency in `info.json` to guarantee load order without requiring the mod.

## Why [investigation]
The **internal entity name of the Lignumis tree is not confirmed** from the mod's source (the source repo wasn't fully browsable). To stay safe, the code probes a candidate list (`wood-tree`, `lignumis-tree`, `tree-lignumis`, `lignum-tree`) and only acts on names that actually exist in `data.raw["tree"]`. If none match, the file is a no-op (no crash).

### What I tried
- Confirmed the left/right split of Circa via `ringworld_left_mask` / `ringworld_right_mask` and the undergrowth-vs-desert tile layout.
- Followed the existing mod-gated update pattern (`enemy-race-manager-updates.lua`) for mutating the planet's `autoplace_settings` at the data-updates stage.

### What's uncertain
- The exact Lignumis tree entity name — confirm and trim/extend `candidate_tree_names` if needed.
- Density factor `0.4` is a first guess; tune for desired forest coverage.

### How to verify in-game
1. Enable Metal-and-Stars + Lignumis, start/visit Circa.
2. Check the left (west, x < 0) half: Lignum trees should generate in the overgrowth zone; the right (desert) half should stay tree-free.
3. If no trees appear, run `/c game.print(serpent.line(prototypes.entity)` filtered for trees (or inspect Lignumis) to get the real tree name and update `candidate_tree_names`.

Closes #38