### PR TITLE
Offshore pump not extracting Gray Goo on Neumann IV

### DIFF
--- a/prototypes/planet/shipyard/shipyard_tiles.lua
+++ b/prototypes/planet/shipyard/shipyard_tiles.lua
@@ -331,7 +331,13 @@ data:extend
     type = "tile",
     order = "a[oil]-b[deep]",
     subgroup = "fulgora-tiles",
-    collision_mask = tile_collision_masks.oil_ocean_deep(),
+    -- Use the standard deep-water collision mask (includes the "water_tile"
+    -- layer) instead of oil_ocean_deep(). The vanilla offshore pump's
+    -- buildability rules require the "water_tile" layer to place on a tile and
+    -- extract its `fluid`; oil_ocean_deep() intentionally omits it (that is why
+    -- Fulgora's oil ocean cannot be offshore-pumped), which prevented the
+    -- offshore pump from extracting Gray Goo on Neumann IV. See issue #44.
+    collision_mask = tile_collision_masks.water(),
     autoplace = {probability_expression = "grey_goo_noise"},
     layer = 3,
     layer_group = "water",


### PR DESCRIPTION
## Problem
An Offshore Pump placed on **Gray Goo** fluid on a freshly generated **Neumann IV** surface does not extract the fluid (reported via the mod portal). Removing third-party mods did not help, pointing at the M&S fluid/tile definition.

## Root cause
`gray-goo-tile` (`prototypes/planet/shipyard/shipyard_tiles.lua`) used `tile_collision_masks.oil_ocean_deep()` — the same collision mask Fulgora's oil ocean uses. That mask deliberately **omits the `water_tile` collision layer**, which is precisely why the vanilla offshore pump cannot be placed on / extract from Fulgora's oil ocean by design.

The offshore pump's buildability rules require the `water_tile` layer to place on a tile and then output that tile's `fluid`. Since Gray Goo inherited the oil-ocean mask, the pump could not extract `fluid = "gray-goo"`, even though the tile correctly declares it.

## Change
Switch `gray-goo-tile` to `tile_collision_masks.water()` (the standard deep-water mask, which includes `water_tile`). The tile already borrows `water-shallow` transitions and uses `layer_group = "water"`, so deep-water semantics are consistent. The offshore pump can now be placed on Gray Goo and outputs `gray-goo` just like a water tile produces water. One-line mask change plus an explanatory comment; no other behavior touched.

## Balance / uncertainty notes
- The reporter-only repro could not be reproduced locally and base-game prototype files were not available in this environment, so the buildability/mask reasoning is based on Factorio 2.0 behavior rather than a live in-game test.
- The deep-water mask makes Gray Goo non-walkable/non-buildable like deep water (previously it had a `walking_speed_modifier`; with the deep-water mask players can't walk on it). If walk-on-Gray-Goo was intentional, an alternative is to keep a shallow/water-shallow-style mask that still includes `water_tile`.
- `gray-goo-tile` is already registered in `foundation`'s `place_as_tile.tile_condition` (data-updates.lua), so it remains coverable by foundation.

## How to verify in-game
1. Generate a new Neumann IV surface and find a Gray Goo pool.
2. Place a vanilla Offshore Pump on a Gray Goo tile (it should now be placeable on the fluid edge like a water tile).
3. Confirm it outputs `gray-goo` fluid into a connected pipe.
4. Confirm foundation can still be placed over Gray Goo.

Closes #44