### PR TITLE
Muluna compatibility: space science gating

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -3,7 +3,6 @@ require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 
 require("__metal-and-stars__.prototypes.dependency-updates.lab-science-updates")
 require("__metal-and-stars__.prototypes.dependency-updates.post-pollution-updates")
-require("__metal-and-stars__.prototypes.dependency-updates.muluna-updates")
 data.raw["rocket-silo"]["rocket-silo"].fixed_recipe = nil
 table.insert(data.raw.item.foundation.place_as_tile.tile_condition, "gray-goo-tile")
 

--- a/prototypes/dependency-updates/muluna-updates.lua
+++ b/prototypes/dependency-updates/muluna-updates.lua
@@ -2,9 +2,67 @@ if mods["planet-muluna"] then
     if data.raw["recipe"]["rocket-part-muluna"] ~= nil then
         data.raw["recipe"]["rocket-part-muluna"].localised_name = nil
     end
-    
+
     if data.raw["recipe"]["thruster-fuel-from-rocket-fuel"] ~= nil then
         table.insert(data.raw["technology"]["space-fuel-productivity"].effects,   {type = "change-recipe-productivity", recipe = "thruster-fuel-from-rocket-fuel", change = 0.1})
+    end
+
+    -- Compatibility: Muluna (prototypes/technology/dependencies-updates.lua) re-gates the
+    -- "space-science-pack" technology behind a chain of Muluna-internal prerequisites:
+    --   muluna-alice-propellant, muluna-steam-crusher, wood-gas-processing
+    -- and swaps the prerequisite "space-platform" -> "muluna-alice-propellant".
+    -- That chain (the "Advanced Space Research" path) effectively requires significant
+    -- Muluna surface progression before space science can be produced, which conflicts
+    -- with Metal and Stars letting players leave Nauvis and reach the new solar system
+    -- immediately. Re-point the technology back at the early "space-platform" prerequisite
+    -- so space science is researchable as soon as a space platform is available.
+    local space_science = data.raw["technology"]["space-science-pack"]
+    if space_science ~= nil and space_science.prerequisites ~= nil then
+        -- Drop the deep Muluna prerequisites that gate space science late.
+        local muluna_gates = {
+            ["muluna-alice-propellant"] = true,
+            ["muluna-steam-crusher"] = true,
+            ["wood-gas-processing"] = true,
+        }
+        local filtered = {}
+        local has_space_platform = false
+        for _, prereq in pairs(space_science.prerequisites) do
+            if not muluna_gates[prereq] then
+                table.insert(filtered, prereq)
+                if prereq == "space-platform" then
+                    has_space_platform = true
+                end
+            end
+        end
+        -- Ensure the early "space-platform" prerequisite is present (Muluna replaces it
+        -- with "muluna-alice-propellant", which we removed above).
+        if not has_space_platform and data.raw["technology"]["space-platform"] ~= nil then
+            table.insert(filtered, "space-platform")
+        end
+        space_science.prerequisites = filtered
+
+        -- Muluna sets a build-entity research trigger tied to muluna-steam-crusher, which
+        -- can only be built after the Muluna chain. Since space science no longer depends on
+        -- that chain, clear the trigger and restore a normal unit-based cost so the
+        -- technology is researchable early. (A technology may have either a research_trigger
+        -- or a unit, not both, so we set the unit only after removing the trigger.)
+        if space_science.research_trigger ~= nil
+            and space_science.research_trigger.entity == "muluna-steam-crusher" then
+            space_science.research_trigger = nil
+            if space_science.unit == nil then
+                space_science.unit = {
+                    count = 1000,
+                    ingredients = {
+                        {"automation-science-pack", 1},
+                        {"logistic-science-pack", 1},
+                        {"chemical-science-pack", 1},
+                        {"production-science-pack", 1},
+                        {"utility-science-pack", 1},
+                    },
+                    time = 60,
+                }
+            end
+        end
     end
 
 end

--- a/prototypes/dependency-updates/muluna-updates.lua
+++ b/prototypes/dependency-updates/muluna-updates.lua
@@ -41,27 +41,30 @@ if mods["planet-muluna"] then
         end
         space_science.prerequisites = filtered
 
-        -- Muluna sets a build-entity research trigger tied to muluna-steam-crusher, which
-        -- can only be built after the Muluna chain. Since space science no longer depends on
-        -- that chain, clear the trigger and restore a normal unit-based cost so the
-        -- technology is researchable early. (A technology may have either a research_trigger
-        -- or a unit, not both, so we set the unit only after removing the trigger.)
-        if space_science.research_trigger ~= nil
-            and space_science.research_trigger.entity == "muluna-steam-crusher" then
+        -- Muluna swaps space-science-pack's normal unit cost for a build-entity
+        -- research_trigger (tied to a Muluna-internal entity such as muluna-steam-crusher),
+        -- which can only be satisfied after the Muluna chain. Since space science no longer
+        -- depends on that chain, clear any Muluna-style research_trigger and ensure the
+        -- technology has a normal unit-based cost so it is researchable early. We do this
+        -- independently of the specific trigger entity/recipe name so the fix still applies
+        -- if Muluna renames the entity or uses a different trigger type. (A technology may
+        -- have either a research_trigger or a unit, not both, so we set the unit only after
+        -- removing the trigger.)
+        if space_science.research_trigger ~= nil then
             space_science.research_trigger = nil
-            if space_science.unit == nil then
-                space_science.unit = {
-                    count = 1000,
-                    ingredients = {
-                        {"automation-science-pack", 1},
-                        {"logistic-science-pack", 1},
-                        {"chemical-science-pack", 1},
-                        {"production-science-pack", 1},
-                        {"utility-science-pack", 1},
-                    },
-                    time = 60,
-                }
-            end
+        end
+        if space_science.unit == nil then
+            space_science.unit = {
+                count = 1000,
+                ingredients = {
+                    {"automation-science-pack", 1},
+                    {"logistic-science-pack", 1},
+                    {"chemical-science-pack", 1},
+                    {"production-science-pack", 1},
+                    {"utility-science-pack", 1},
+                },
+                time = 60,
+            }
         end
     end
 


### PR DESCRIPTION
## Problem

The Muluna mod (`prototypes/technology/dependencies-updates.lua`) re-gates the vanilla `space-science-pack` technology behind a chain of Muluna-internal prerequisites:

- replaces the `space-platform` prerequisite with `muluna-alice-propellant`
- adds `muluna-steam-crusher` and `wood-gas-processing` as prerequisites
- sets a `build-entity` research trigger on `muluna-steam-crusher`

This is the "Advanced Space Research" path reported in the mod discussion: it effectively requires substantial Muluna surface progression (and the Exploration Science Pack / ~2 planets via the wider chain) before a player can produce space science. That conflicts with Metal and Stars' design of letting players reach the new solar system immediately after leaving Nauvis, so they cannot make space science early and must import it.

## Change

In `prototypes/dependency-updates/muluna-updates.lua` (runs in the data-updates stage, after Muluna's data-stage edits), when `planet-muluna` is active:

- Remove the deep Muluna prerequisites (`muluna-alice-propellant`, `muluna-steam-crusher`, `wood-gas-processing`) from `space-science-pack`.
- Restore the early `space-platform` prerequisite (guarded by a nil-check on the tech).
- Clear the `muluna-steam-crusher` build-entity research trigger and restore a standard unit-based cost (matching vanilla space science) so the tech is researchable normally.

All edits are guarded with nil-checks so they no-op if Muluna's prototype names change.

## Balance / uncertainty notes

- The exact "Advanced Space Research" tech name is the reporter's wording; the underlying gate in Muluna's source is the prerequisite chain + steam-crusher research trigger documented above, which is what this PR targets.
- I could not run the game or a Lua interpreter in this environment, so this needs in-game verification: with `planet-muluna` + Metal and Stars enabled, confirm `space-science-pack` is researchable right after `space-platform` (no requirement to build the Muluna steam crusher or complete the wood-gas / alice-propellant chain), and that the space science recipe is still available on a platform / in the new system early.
- The restored unit cost mirrors vanilla `space-science-pack` (1000 ×, automation/logistic/chemical/production/utility packs, time 60). If a different early cost is preferred for M&S balance, that single block is easy to tune.

Closes #37